### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/app/api/metadata/gitcoin/[address]/route.ts
+++ b/app/api/metadata/gitcoin/[address]/route.ts
@@ -53,7 +53,13 @@ function createResponse(score: number, stamps: any[]): StampResponse {
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const address = req.nextUrl.searchParams.get("address");
 
-  if (!address || !isValidEthereumAddress(address)) {
+  // Extra strict validation: only allow lowercase 0x-prefixed 40 hex digits
+  const STRICT_ETH_ADDR_RE = /^0x[a-f0-9]{40}$/;
+  if (
+    !address ||
+    !isValidEthereumAddress(address) ||
+    !STRICT_ETH_ADDR_RE.test("0x" + address.replace(/^0x/i, "").toLowerCase())
+  ) {
     return NextResponse.json(createResponse(0, []));
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/web3bio/security/code-scanning/7](https://github.com/Dargon789/web3bio/security/code-scanning/7)

To completely mitigate SSRF possibilities, we need to ensure the interpolated user input into the URL path does not allow for any path traversal or URL manipulation. The current `isValidEthereumAddress` function should strictly enforce that `address` consists only of the allowed Ethereum address characters (`0x` + 40 lowercase hexadecimal digits), without allowing any extra characters. After validation/normalization, the value should not contain slashes, periods, or any reserved URI characters.

For extra certainty and defense-in-depth, we should:
- Add a stricter validation regex that rejects anything except the expected form (e.g., `/^0x[a-f0-9]{40}$/`).
- Use this stricter check before constructing the URL or reject the request if invalid.
- (Optional but recommended) Make the `fetchStamps` function accept only a validated address or refuse unsafe forms.

You only need to edit within the code shown in the snippet in `app/api/metadata/gitcoin/[address]/route.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enforce strict Ethereum address validation in the GET route to mitigate SSRF risks by rejecting any input that does not match the exact lowercase 0x-prefixed 40-hex-digit format.

Bug Fixes:
- Prevent SSRF by rejecting requests with invalid or manipulated Ethereum addresses before URL construction.

Enhancements:
- Add STRICT_ETH_ADDR_RE regex to ensure only lowercase "0x" + 40 hexadecimal characters are accepted.
- Normalize and re-validate the address string to lowercase and enforce the strict regex check.